### PR TITLE
完善首页 SEO 和英文首页内容

### DIFF
--- a/data/en/banner.yml
+++ b/data/en/banner.yml
@@ -4,9 +4,9 @@ banner:
   bg_image_webp: "images/backgrounds/hero-area.webp"
   bg_image: "images/backgrounds/hero-area.jpg"
   icon: "" # themify icon pack : https://themify.me/themify-icons
-  title: "OpenTenBase an enterprise-level distributed HTAP open source database"
-  content: "OpenTenBase is an enterprise-level distributed HTAP open source database. It has high scalability, commercial database syntax compatibility, distributed HTAP engine, multi-level disaster recovery and multi-dimensional resource isolation. It has been successfully used in core businesses in finance, medical, aerospace and other industries system."
+  title: "OpenTenBase An Open and Neutral Open-Source Database"
+  content: "OpenTenBase is the community edition of TDSQL, an enterprise-grade distributed database. It includes two database kernels, OpenTenBase and TXSQL, and provides high scalability, compatibility with commercial database syntax, distributed processing, multi-level disaster recovery, and multi-dimensional resource isolation. It has been deployed in mission-critical systems across financial services, healthcare, aerospace, and other industries."
   button:
     enable: true
-    label: "Explore Us"
+    label: "View on GitHub"
     link: "https://github.com/OpenTenBase/OpenTenBase"

--- a/data/en/cta.yml
+++ b/data/en/cta.yml
@@ -3,7 +3,7 @@ cta:
   enable: true
   bg_image: "images/backgrounds/bg-white-wall.jpg"
   bg_image_webp: "images/backgrounds/bg-white-wall.webp"
-  title: "Explore more features of OpenTenBase"
+  title: "Explore&nbsp;More&nbsp;OpenTenBase&nbsp;Features OpenTenBase GitHub Repository"
   # content : "OpenTenBase code repository"
   link: "https://github.com/OpenTenBase/OpenTenBase"
   button:

--- a/data/en/feature.yml
+++ b/data/en/feature.yml
@@ -3,25 +3,25 @@ feature:
   enable: true
   image: images/about/about-business-man.jpg
   image_webp: images/about/about-business-man.webp
-  title: Install, Use, Contribute? Get started quickly with OpenTenBase!
+  title: Install, Use, Contribute — Get Started with OpenTenBase
   content:
   feature_item:
     # feature item loop
     - title: What is OpenTenBase
       icon: ti-help # themify icon pack : https://themify.me/themify-icons
-      content: OpenTenBase is an open source distributed database that can easily handle the storage, analysis and query of billions of data.
+      content: OpenTenBase is an open-source distributed database designed to efficiently handle large-scale data storage, analytics, and queries.
 
       # feature item loop
     - title: Quick Start
       icon: ti-wand # themify icon pack : https://themify.me/themify-icons
-      content: OpenTenBase architecture, introduction, compilation and installation, cluster running status, start and stop, etc.
+      content: Learn about the OpenTenBase architecture, source code compilation and installation, cluster status, startup and shutdown, and more.
 
       # feature item loop
-    - title: Basic Use
+    - title: Basic Usage
       icon: ti-book # themify icon pack : https://themify.me/themify-icons
-      content: Creation of shard table, hot and cold partition table, copy table, and basic DML operations.
+      content: Create shard tables, hot/cold partitioned tables, and replication tables, and perform basic DML operations.
 
       # feature item loop
     - title: Contribute
       icon: ti-write # themify icon pack : https://themify.me/themify-icons
-      content: If you have good comments or suggestions, welcome to create Issues or Pull Requests to contribute to the OpenTenBase open source community.
+      content: If you have suggestions or improvements, feel free to open an Issue or Pull Request and contribute to the OpenTenBase community.

--- a/data/en/service.yml
+++ b/data/en/service.yml
@@ -1,40 +1,40 @@
 ################################# Service #################################
 service:
   enable: true
-  title: Key Feature
+  title: Key Features
   service_item:
     # service item loop
     - name: Commercial Database Compatibility
       icon: ti-world # themify icon pack : https://themify.me/themify-icons
-      content: Fully compatible with SQL2011, Supports commercial database syntax
+      content: Full SQL:2011 compatibility with support for Oracle-compatible syntax.
       content_2:
 
     # service item loop
-    - name: PostgreSQL Compatibility
+    - name: MySQL and PostgreSQL Compatibility
       icon: ti-layout # themify icon pack : https://themify.me/themify-icons
-      content: Highly compatible with PostgreSQL syntax and following the community ecology
+      content: Provides strong compatibility with the MySQL and PostgreSQL ecosystems through the TXSQL and OpenTenBase kernels, respectively.
       content_2:
 
     # service item loop
-    - name: Complete Distributed Transaction Capabilities
+    - name: Complete Distributed Transaction Support
       icon: ti-blackboard # themify icon pack : https://themify.me/themify-icons
-      content: Complete distributed transaction ACID capabilities to ensure distributed read consistency
+      content: Provides full ACID-compliant distributed transactions and consistent reads across the distributed system.
       content_2:
 
     # service item loop
-    - name: HTAP Dual Engine
+    - name: Dual-Kernel Architecture
       icon: ti-palette # themify icon pack : https://themify.me/themify-icons
-      content: Equipped with efficient OLTP and powerful OLAP dual engine capabilities, supporting PB level
-      content_2: Efficient processing of massive data and efficient distributed execution capabilities
-
-    # service item loop
-    - name: Flexible Extension
-      icon: ti-package # themify icon pack : https://themify.me/themify-icons
-      content: Distributed flexible expansion, distributed efficient elastic expansion and contraction
+      content: Includes both the OpenTenBase and TXSQL kernels, with efficient distributed execution and support for petabyte-scale data processing.
       content_2:
 
     # service item loop
-    - name: Superior performance
+    - name: High Performance
       icon: ti-pulse # themify icon pack : https://themify.me/themify-icons
-      content: Superior performance, good distributed elastic expansion, supporting high concurrency and high-speed throughput
+      content: Provides elastic distributed scalability with support for high concurrency and high throughput.
+      content_2:
+
+    # service item loop
+    - name: Data + AI
+      icon: ti-light-bulb # themify icon pack : https://themify.me/themify-icons
+      content: Supports distributed vector search and multimodal Data + AI analytics.
       content_2:

--- a/data/en/testimonial.yml
+++ b/data/en/testimonial.yml
@@ -3,44 +3,49 @@ testimonial:
   enable: true
   #  bg_image : images/backgrounds/bg-testimonial.jpg
   #  bg_image_webp : images/backgrounds/bg-testimonial.webp
-  title: "Messages from Celebrities"
+  title: "Community Voices"
   btnNext: "ti-angle-right" # themify icon pack : https://themify.me/themify-icons
   btnPre: "ti-angle-left" # themify icon pack : https://themify.me/themify-icons
   testimonial_item:
 
     # testimonial item loop
-    - name: "FENG Guanlin"
-      position : "Secretary General of OpenAtom Foundation"
-      content: "I am very happy to see that Tencent can open source OpenTenBase, a basic software database project that has been developed for many years and has passed the test of massive business scenarios, and donated it to the foundation. In the future, the foundation will uphold a neutral and open attitude and work with the industry to build OpenTenBase into a globally influential excellent open source projects."
+    - name: "CHENG Xiaoming"
+      position : "Secretary-General, OpenAtom Foundation"
+      content: "The establishment of the OpenTenBase Community Committee marks an important step toward open and neutral governance for the OpenTenBase project. We sincerely appreciate the active participation and strong support of all community member organizations. Going forward, we will continue to support the OpenTenBase Community Committee in upholding the principles of open governance, bringing together core database developers, ecosystem builders, and users to create an open, inclusive, and vibrant collaboration platform. We look forward to advancing database innovation and building OpenTenBase into a solid data foundation for open digital infrastructure in China and around the world. We also welcome more organizations committed to open source to join the community and contribute to its continued growth."
 
     # testimonial item loop
     - name: "WANG Yicheng"
       #image: images/client/client-1.jpg
       #image_webp: images/client/client-1.webp
-      position : "General Manager of Tencent Cloud Database"
-      content: "In recent years, the amount of data has continued to increase dramatically. The development of the Internet, IoT, and smart manufacturing has brought explosive growth of data. The development of cloud computing has made data aggregation easier. At present, TDSQL has covered a complete database product system that integrates financial-grade distributed, cloud-native, analytical and other multi-engines, and provides industry-leading financial-grade high availability, storage and calculation separation, data warehouse, enterprise-level security and other capabilities. In the future, we will continue to invest in and break through core database technologies, create a more healthy and sustainable database ecosystem and open source community, and provide long-term impetus for the digital transformation of enterprises."
+      position : "General Manager, Tencent Cloud Database"
+      content: "Data volumes continue to grow rapidly as the Internet, IoT, intelligent manufacturing, and cloud computing accelerate data generation and aggregation. TDSQL now provides a comprehensive database product portfolio covering financial-grade distributed databases, cloud-native databases, analytical engines, and other technologies, with capabilities including financial-grade high availability, storage-compute separation, data warehousing, and enterprise security. We will continue investing in core database technologies and working with the industry to build a healthy and sustainable database ecosystem and open-source community, providing long-term momentum for enterprise digital transformation."
+
+    # testimonial item loop
+    - name: "PAN Anqun"
+      position : "General Manager of Database R&D, Tencent Cloud"
+      content: "OpenTenBase fills an important gap in open-source PostgreSQL-based distributed OLTP systems. It combines HTAP capabilities, distributed transaction consistency, broad SQL compatibility, and complex query processing to provide strong support for enterprise digital transformation. OpenTenBase supports both OLTP and OLAP workloads, helping reduce business architecture complexity and cost. It uses global transaction management to maintain transaction consistency in distributed environments, provides strong PostgreSQL and Oracle compatibility, and includes a distributed query optimizer designed to significantly improve complex query performance."
 
     # testimonial item loop
     - name: "PING Lei"
-      position : "Vice General Manager of Cybersecurity Center of CHN Energy"
-      content: "Let’s work together to share the wisdom of open source databases! We are very happy to work together with the OpenTenBase open source distributed database community to work together on this open source database project. We believe that by working together, we can create a more high-quality, efficient, and reliable database product and provide better support and services to developers around the world. We look forward to continuing to work closely with OpenTenBase to jointly solve the technical problems encountered and jointly explore the future of database technology. We believe that through openness and sharing in the open source community, we can achieve greater success!"
+      position : "Deputy General Manager, Cybersecurity Center, CHN Energy Information Technology"
+      content: "We are pleased to work with the OpenTenBase open-source distributed database community and jointly contribute to this open-source database project. Through collaboration, we believe we can build a higher-quality, more efficient, and more reliable database product and provide better support and services for developers worldwide. We look forward to continuing our close cooperation with OpenTenBase, solving technical challenges together, exploring the future of database technology, and achieving greater success through the openness and shared innovation of the open-source community."
 
     # testimonial item loop
     - name: "BAI Shi"
-      position : "Vice Director of China Chengtong"
-      content: "China Chengtong is the \"reform toolbox\" for the high-quality development of central enterprises. We are very happy to participate in the open source database community initiated by Tencent and work with the OpenTenBase community to promote the open source ecosystem of domestic databases. At the same time, we will use the concept of pioneering, reform and innovation to continue Promote the digital transformation of state-owned enterprises."
+      position : "Deputy Director, Chengtong Digital Technology Co., Ltd."
+      content: "China Chengtong serves as a key platform supporting the high-quality reform and development of central state-owned enterprises. We are pleased to participate in the open-source database community initiated by Tencent and to work with the OpenTenBase community to advance China's open-source database ecosystem. We will continue to embrace innovation and practical exploration while supporting the digital transformation of state-owned enterprises."
 
     # testimonial item loop
     - name: "WANG Yunlong"
-      position : "Product Director of Tencent Cloud Database"
-      content: "OpenTenBase is an open source distributed database deeply practiced within Tencent. After 10 years of development in finance, games, advertising, social networking and other businesses, it has been gradually promoted to applications in thousands of industries. The Tencent Cloud distributed database TDSQL team has been working hard for ten years. In the future, we will work with the industry to create an open source ecosystem for domestic databases and an ecosystem compatible with Oracle databases to better assist enterprises in digital transformation and cope with the challenges of high performance and high availability of massive data. , and lower the user threshold."
+      position : "Product Director, Tencent Cloud Database"
+      content: "OpenTenBase is an open-source distributed database that has been extensively used within Tencent and refined through more than a decade of practice in financial services, gaming, advertising, social networking, and other businesses before expanding into a wide range of industries. Looking ahead, the Tencent Cloud TDSQL team will continue working with the industry to build an open-source domestic database ecosystem and strengthen Oracle-compatible database capabilities, helping enterprises address high-performance and high-availability requirements for massive data while reducing the barrier to database adoption."
 
     # testimonial item loop
     - name: "ZHAO Zhenping"
-      position : "Former Chairman of PostgreSQL Chinese Community"
-      content: "I wish the Tencent OpenTenBase community to delve deeply into the database field, serve China and serve the world. Become a large and influential technology community in the world."
+      position : "Former Chair of the PostgreSQL Chinese Community"
+      content: "Best wishes to the OpenTenBase community as it continues to advance database technology, serve users in China and around the world, and grow into an influential global technology community."
 
     # testimonial item loop
     - name: "BAI Guohua"
-      position : "Vice Chairman and Secretary General of China PostgreSQL Association"
-      content: "OpenTenBase is an enterprise-level distributed HTAP open source database that fills the gap in the industry's open source distributed OLTP system based on PostgreSQL. The Tencent Cloud TDSQL PG team also applies the open source kernel to core business systems in finance, government, telecommunications, medical, aerospace and other industries. In the future, China PostgreSQL Association will work with Tencent to promote open source products to a broader application market."
+      position : "Vice Chair and Secretary-General, China PostgreSQL Association"
+      content: "As an enterprise-grade distributed HTAP open-source database, OpenTenBase fills an important gap in open-source PostgreSQL-based distributed OLTP systems. The Tencent Cloud TDSQL PG team has deployed its open-source database kernel in mission-critical systems across financial services, government, telecommunications, healthcare, aerospace, and other industries. Going forward, the China PostgreSQL Association will continue working with Tencent to bring this open-source technology to a broader range of users and application scenarios."

--- a/hugo.toml
+++ b/hugo.toml
@@ -140,12 +140,12 @@ url = "#blog"
 weight = 2
 
 [[Languages.en.menu.main]]
-name = "Event"
+name = "Events"
 url = "#event"
 weight = 3
 
 [[Languages.en.menu.main]]
-name = "Document"
+name = "Documentation"
 url = "https://docs.opentenbase.org/en/"
 weight = 4
 
@@ -155,7 +155,7 @@ url = "https://github.com/OpenTenBase/OpenTenBase/tags"
 weight = 5
 
 [[Languages.en.menu.main]]
-name = "Code"
+name = "GitHub"
 url = "https://github.com/OpenTenBase/OpenTenBase"
 weight = 6
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,11 +1,11 @@
 - id: blogTitle
-  translation: Latest Post
+  translation: Technical Blog
 - id: newsTitle
-  translation: Latest News
+  translation: Community News
 - id: eventTitle
-  translation: Latest Event
+  translation: Latest Events
 - id: readMore
-  translation: Read more
+  translation: Read More
 - id: viewAllevent
   translation: View All Events
 - id: share
@@ -39,4 +39,4 @@
 - id: newPublish
   translation: Latest
 - id: viewAllnews
-  translation: VIEW ALL NEWS
+  translation: View All News


### PR DESCRIPTION
## 修改内容
- 完善首页 SEO 元信息和标题语义，包括 robots.txt、Open Graph、Twitter Card、默认分享图以及首页标题标签语义
- 同步英文首页内容，包括 Banner、关键特性、快速入门、CTA、大咖寄语、英文导航和 i18n 文案

## 验证
- 使用 Hugo 0.116.1 本地构建通过
- `/en/` 英文首页正常生成
- 构建输出未提交 `hugo_stats.json`